### PR TITLE
Add task to match errands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ env/
 .env
 loadEnv.sh
 sendgrid.env
-
+celerybeat*

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-tasks: celery -A shield worker --pool=solo -l info
+tasks: celery -A shield worker --pool=solo -B -l info
 release: python manage.py migrate
 web: gunicorn shield.wsgi --log-file -

--- a/errand_matcher/tasks.py
+++ b/errand_matcher/tasks.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from celery import shared_task
-from errand_matcher.models import User
+from errand_matcher.models import User, Volunteer
 
 
 @shared_task
@@ -11,3 +11,8 @@ def add(x, y):
 @shared_task
 def count_users():
     return User.objects.count()
+
+@shared_task
+def match_errands():
+    count = Volunteer.objects.count()
+    print(count)

--- a/shield/settings.py
+++ b/shield/settings.py
@@ -154,7 +154,7 @@ CELERY_TASK_SERIALIZER = 'json'
 CELERY_BEAT_SCHEDULE = {
  'match-errands-every-five-minutes': {
        'task': 'errand_matcher.tasks.match_errands',
-       'schedule': 5.0,
+       'schedule': 60.0,
        'args': (),
     },
 }

--- a/shield/settings.py
+++ b/shield/settings.py
@@ -151,5 +151,12 @@ CELERY_BROKER_TRANSPORT_OPTIONS = { 'visibility_timeout': 3600 }
 CELERY_ACCEPT_CONTENT = ['json']
 CELERY_RESULT_BACKEND = os.environ.get('REDIS_URL', '')
 CELERY_TASK_SERIALIZER = 'json'
+CELERY_BEAT_SCHEDULE = {
+ 'match-errands-every-five-minutes': {
+       'task': 'errand_matcher.tasks.match_errands',
+       'schedule': 5.0,
+       'args': (),
+    },
+}
 
 django_heroku.settings(locals())


### PR DESCRIPTION
To Do:
- [x] :bug: Fix scheduler timing

Test Plan:
1. `celery -A shield worker -B -l DEBUG`: You should see in output that the task will run every 1 minute and print out the number of Volunteers in the DB. This is currently ~38.