### PR TITLE
Limit errand matching to hours of operation

### DIFF
--- a/errand_matcher/templates/errand_matcher/index.html
+++ b/errand_matcher/templates/errand_matcher/index.html
@@ -128,6 +128,15 @@
 		  	    <p class="details-text">Keep the receipt from the purchase. In some cases, it may be possible for the community member to call the grocery store in advance to pay for groceries with a credit card. You should coordinate with the community member in advance for the method of payment for the items you purchase. You should not be paid more than what you paid as this is a volunteer service. If the community member is ill, coordinate an electronic method of payment to avoid handling cash (minimizing chances of disease transmission). In general we strongly encourage using a digital form of payment whenever possible to help maintain social distancing.</p>
 		    </div>
 		</div>
+		<div class="collapsible-container">
+			<div class="collapsible">
+		  	    <img src="{% static 'css/icons/expand_more_24px.png' %}" class="collapsible-image">
+		  	    <p class="title-text">When and how do I get a service request? </p>
+		    </div>
+		    <div class="collapsible-content">
+		  	    <p class="details-text">Our automatic matching system will send you a text message between 8am-8:30pm if someone in your neighborhood needs a delivery.</p>
+		    </div>
+		</div>
 
 		<h5 class="h5-heading">Requester</h5>
 
@@ -183,6 +192,24 @@
 		    </div>
 		    <div class="collapsible-content">
 		  	    <p class="details-text">Our service is currently limited to grocery and pharmacy shopping, though we hope to broaden this in the future. We suggest you reach out to other services, like Cambridge Mutual Aid or use Facebook’s request help feature.</p>
+		    </div>
+		</div>
+		<div class="collapsible-container">
+			<div class="collapsible">
+		  	    <img src="{% static 'css/icons/expand_more_24px.png' %}" class="collapsible-image">
+		  	    <p class="title-text">When can I submit a request?</p>
+		    </div>
+		    <div class="collapsible-content">
+		  	    <p class="details-text">You can submit a request on our website anytime, any day! We will process all requests submitted between 8am-6pm on the same day (including weekend) to match you with a volunteer. Submissions received outside of this window will be processed the next day.</p>
+		    </div>
+		</div>
+		<div class="collapsible-container">
+			<div class="collapsible">
+		  	    <img src="{% static 'css/icons/expand_more_24px.png' %}" class="collapsible-image">
+		  	    <p class="title-text">When can I expect my delivery?</p>
+		    </div>
+		    <div class="collapsible-content">
+		  	    <p class="details-text">The volunteer will reach out to arrange a convenient drop-off time based on the urgency level indicated in the request submission form.</p>
 		    </div>
 		</div>
 

--- a/shield/settings.py
+++ b/shield/settings.py
@@ -171,7 +171,7 @@ CELERY_TASK_SERIALIZER = 'json'
 CELERY_BEAT_SCHEDULE = {
     'match-errands-every-thirty-minutes': {
        'task': 'errand_matcher.tasks.match_errands',
-       'schedule': crontab(minute='*/30'),
+       'schedule': crontab(minute='*/30', hour='11-22'),
        'args': (),
     },
     # 'send-complete-messages-every-day': {


### PR DESCRIPTION
Run the celery task queue to test. Might be best to test this configuration in staging. Currently, I have the tasks starting at 8am instead of 7:30am. If this is a problem let me know and I can fix. It's just not as straight forward.